### PR TITLE
Improve with an optionalExts so we can control which extensions we wa…

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var addAllFilesApp = function () {
   var contexts = null;
   var packageRoot = null;
 
-  var main = function (rootDir, destDir) {
+  var main = function (rootDir, destDir, optionalExts) {
     contexts = {
       lib: [],
       client: [],
@@ -26,13 +26,17 @@ var addAllFilesApp = function () {
       both: []
     };
 
+    if (optionalExts) {
+        exts = optionalExts;
+    }
+
     if (destDir) {
       packageRoot = Path.resolve(destDir);
     } else {
       packageRoot = Path.resolve(rootDir);
     }
 
-    srcRoot = Path.resolve(rootDir)
+    var srcRoot = Path.resolve(rootDir);
 
     if(!packageRoot.endsWith("/")) {
       packageRoot = packageRoot + "/";


### PR DESCRIPTION
…nt to include ;)

I'm building kind of a special package setup where i want to provide ".ts" files directly, so i can import them in my own meteor components and extend from them, and i'm also using ".scss" instead of ".css" - with this little change, i'm able now to control my call like this:

`var onUseFiles = MeteorLoad.getAllFiles('./src', null, ['ts', 'scss', 'html']);`